### PR TITLE
refs: #48

### DIFF
--- a/demo/CalendarDemo.jsx
+++ b/demo/CalendarDemo.jsx
@@ -115,7 +115,35 @@ class Demo extends React.Component {
           <Calendar
             showToday
             showTime={false}
-            allowClear={false}
+            allowClear
+            showSecond={false}
+            locale="en-us"
+            yearSelectOffset={100}
+            yearSelectTotal={200}
+            size="middle"
+            disabledTime={() => (
+              {
+                disabledMinutes: () => disabledMinutes,
+              }
+            )}
+            value={value}
+            onSelect={this.onSelect}
+            showDateInput
+          />
+        </div>
+        <div
+          className="kuma-form-field"
+          style={{
+            width: '50px',
+          }}
+        >
+          <p>
+            显示空间不够
+          </p>
+          <Calendar
+            showToday
+            showTime={false}
+            allowClear
             showSecond={false}
             locale="en-us"
             yearSelectOffset={100}
@@ -292,7 +320,7 @@ class Demo extends React.Component {
           </p>
           <RangeCalendar
             size="middle"
-            value={rangeValue}
+            value={[undefined, undefined]}
             onSelect={(v, formatted) => {
               console.log(v, formatted);
               this.onRangeSelect(v, formatted);

--- a/src/YearCalendar.jsx
+++ b/src/YearCalendar.jsx
@@ -184,7 +184,7 @@ YearCalendar.propTypes = {
   hasTrigger: PropTypes.bool,
   showDateInput: PropTypes.bool,
   align: PropTypes.object,
-  transitionName: PropTypes.bool,
+  transitionName: PropTypes.string,
 };
 
 export default YearCalendar;

--- a/src/style/common/Calendar.less
+++ b/src/style/common/Calendar.less
@@ -207,6 +207,14 @@
   position: relative;
   display: inline-block;
   width: 100%;
+  min-width: 80px;
+
+  .kuma-input{
+    padding-right: 28px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+
   .kuma-input[readonly] {
     background-color: white;
     border-color: @border-color;


### PR DESCRIPTION
1. auto hidden value text when width is too small
2. give a min-width to input-span: 80px which can at least show full year like 2019
3. fix a wrong prop type of YearCalendar.transitionName